### PR TITLE
ci: removed changelog.changelog_file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ prerelease_token = "rc"
 prerelease = false
 
 [semantic_release.changelog]
-changelog_file = ""
 exclude_commit_patterns = []
 mode = "init"
 insertion_flag = "<!-- version list -->"


### PR DESCRIPTION
Addressing this warning:

 WARNING  [config.changelog_file_deprecation_warning]    config.py:182
                    The 'changelog.changelog_file' configuration                
                    option is moving to                                         
                    'changelog.default_templates.changelog_file'.               
                    Please update your configuration as the                     
                    compatibility will break in v10.   