### PR TITLE
fix: increase element length to 20

### DIFF
--- a/migrations/versions/a760c1d5f774_.py
+++ b/migrations/versions/a760c1d5f774_.py
@@ -22,11 +22,11 @@ def upgrade():
         batch_op.drop_column('level')
         batch_op.add_column(sa.Column('type', sa.String(length=15), nullable=False, server_default='none'))
         batch_op.alter_column('name', existing_type=sa.String(length=15))
-        batch_op.alter_column('element', existing_type=sa.String(length=10), type_=sa.String(length=15))
+        batch_op.alter_column('element', existing_type=sa.String(length=10), type_=sa.String(length=20))
 
 def downgrade():
     with op.batch_alter_table('materia', schema=None) as batch_op:
         batch_op.add_column(sa.Column('level', sa.Integer(), nullable=False, server_default=sa.text('1')))
         batch_op.alter_column('name', existing_type=sa.String(length=30))
-        batch_op.alter_column('element', existing_type=sa.String(length=15), type_=sa.String(length=10))
+        batch_op.alter_column('element', existing_type=sa.String(length=20), type_=sa.String(length=10))
         batch_op.drop_column('type')


### PR DESCRIPTION
- sqlite doesn't respect my max length apparently
- have increased length from 15 to 20
- failing case was element below being 18 chars

```
{
    "element": "fire/ice/lightning",
    "id": "45",
    "name": "Kujata",
    "type": "summon"
  },
```