### PR TITLE
Fix ci failures where telemetry was incorrectly initialised

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,4 @@
 # DATABASE_URL=add_db_connection_here
 # LOGFIRE_ENVIRONMENT=environment name for telemetry
 # SERVICE_NAME=service name for telemetry
+# DISABLE_TELEMETRY=1 to disable, 0 to enable

--- a/.github/workflows/manual-trigger.yml
+++ b/.github/workflows/manual-trigger.yml
@@ -46,6 +46,6 @@ jobs:
 
       - name: Upgrade db
         run: |
-          flask db current
-          flask db heads
-          flask db upgrade
+          DISABLE_TELEMETRY=1 flask db current
+          DISABLE_TELEMETRY=1 flask db heads
+          DISABLE_TELEMETRY=1 flask db upgrade

--- a/app.py
+++ b/app.py
@@ -16,7 +16,10 @@ from telemetry.telemetry import telemetry
 import logging
 logger = logging.getLogger(__name__)
 
-def create_app(is_testing=False):
+def create_app():
+    """
+    Start the core app, initialise db, app configs & telemetry. 
+    """
     logger.info('starting up app')
     app = Flask(__name__)
     CORS(app, methods=["GET", "POST", "PUT", "DELETE"])
@@ -24,9 +27,7 @@ def create_app(is_testing=False):
     set_db(app)
     register_api_routes(app)        
 
-    skip_telemetry = is_testing or 'flask' in sys.argv[0]
-
-    if not skip_telemetry:
+    if os.getenv("DISABLE_TELEMETRY") != "1":
         setup_logging()
         telemetry.initialise(app)
     else:

--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+import sys
 import os
 from flask import Flask
 from flask_smorest import Api
@@ -22,7 +23,10 @@ def create_app(is_testing=False):
     set_app_configs(app)
     set_db(app)
     register_api_routes(app)        
-    if not is_testing:
+
+    skip_telemetry = is_testing or 'flask' in sys.argv[0]
+
+    if not skip_telemetry:
         setup_logging()
         telemetry.initialise(app)
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from db import db
 
 @pytest.fixture
 def app():
-    app = create_app(is_testing=True)
+    app = create_app()
     app.testing = True
     with app.app_context():
         db.create_all()


### PR DESCRIPTION
Resolves https://github.com/alexandlazaris/FFVII-API/issues/45

Flask commands were initialising telemetry, which did not have the env sourced at those times. 

Now, tele setup is by default and only skipped if needed using env var. 